### PR TITLE
deeplink expiry redirection fixed-3841

### DIFF
--- a/src/app/deeplink-redirect/deeplink-redirect.component.ts
+++ b/src/app/deeplink-redirect/deeplink-redirect.component.ts
@@ -132,7 +132,7 @@ export class DeeplinkRedirectComponent {
     this.apiService.post(urlConfig.observation.observationVerifyLink+this.linkId+"?createProject=false",this.apiService.profileData).pipe(
       catchError((err: any) => {
         this.toastService.showToast(err?.error?.message ?? 'MSG_INVALID_LINK', 'danger');
-        this.router.navigate([`/listing/${this.type}`]);
+        this.navigateToHomePage();
         return EMPTY;
       })
     ).subscribe((res:any)=>{
@@ -151,7 +151,7 @@ export class DeeplinkRedirectComponent {
         ).pipe(
           catchError((err: any) => {
             this.toastService.showToast(err?.error?.message ?? 'MSG_INVALID_LINK', 'danger');
-            this.router.navigate([`/listing/${this.type}`]);
+            this.navigateToHomePage();
             return EMPTY;
           })
         )
@@ -188,6 +188,11 @@ export class DeeplinkRedirectComponent {
     },
     replaceUrl:true
     });
+  }
+
+  navigateToHomePage(){
+    const baseUrl = window.location.origin;
+    window.location.href = baseUrl+`/home`;
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for survey and observation deeplinks. If loading fails, the app now performs a full redirect to the Home page for a clean recovery.
  * Ensures users are not left on an invalid or partially loaded view after a deeplink error, leading to more reliable navigation.
  * Provides consistent fallback behavior across deeplink types by standardizing the redirect to Home on failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->