### PR TITLE
Toast timing increase in the listing page

### DIFF
--- a/src/app/deeplink-redirect/deeplink-redirect.component.ts
+++ b/src/app/deeplink-redirect/deeplink-redirect.component.ts
@@ -47,13 +47,11 @@ export class DeeplinkRedirectComponent {
     if (event.data?.type === 'START') {
       const stateData = event.data.data;
         if(stateData?.isATargetedSolution){
-        this.router.navigate([
-          'details',
-          stateData?.assessment?.name,
-          stateData?.programId,
-          stateData?.solution?._id,
-          false
-        ]);
+          this.router.navigate([
+            'entityList',
+            stateData?.solution?._id,
+            stateData?.solution?.name
+          ], { replaceUrl:true });
         }
     }
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep link redirects: users now land on the entity list with history replacement, reducing redundant back navigation steps.
  * Standardized error toasts with explicit display times for clarity: 9 seconds for observation link issues and 90 seconds for survey link issues.
  * Maintains existing fallback behavior after errors: show a toast and return to the home screen, ensuring consistent recovery flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->